### PR TITLE
Removing use of RTC for subsecond timestamps

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -445,7 +445,7 @@ int main(void)
 
 		  RTC_TimeTypeDef lTime = sTime;
 		  LocalTime = CanFDFrame.time;
-		  lTime.SubSeconds += LocalTime % 1000;
+		  uint32_t milliseconds = LocalTime % 1000;
 		  LocalTime = LocalTime/1000;
 		  lTime.Seconds += LocalTime % 60;
 		  if(lTime.Seconds >= 60){
@@ -463,7 +463,7 @@ int main(void)
       //Write to SD Card
 		  //date/time, CANID, Data
 		  CFDW = sprintf(CanFDWrite, "%u.%u.%u %u:%u:%u.%u,0x%X,",
-				  sDate.Date,sDate.Month,sDate.Year, lTime.Hours,lTime.Minutes,lTime.Seconds,lTime.SubSeconds,
+				  sDate.Date,sDate.Month,sDate.Year, lTime.Hours,lTime.Minutes,lTime.Seconds,milliseconds,
 				  CanFDFrame.id);
 
 		  CFDW = CANFD_Data_Process(CanFDWrite, CFDW);


### PR DESCRIPTION
I don't think we understood how the RTC subseconds work.

Instead of spending ages figuring it out, I think it makes sense to remove the use of the RTC for the subsecond part of the timestamp and instead just assume that when the board powers up and grabs the time and date from the RTC the subsecond value is 0.

It just means that our absolute time/date timestamp won't be accurate to milliseconds but I don't think that actually matters.
